### PR TITLE
Add parentheses to third-from-last commit() call

### DIFF
--- a/Lesson_1/lotsofmenus.py
+++ b/Lesson_1/lotsofmenus.py
@@ -361,7 +361,7 @@ menuItem1 = MenuItem(name="Chantrelle Toast", description="Crispy Toast with Ses
                      price="$5.95", course="Appetizer", restaurant=restaurant1)
 
 session.add(menuItem1)
-session.commit
+session.commit()
 
 menuItem1 = MenuItem(name="Guanciale Chawanmushi", description="Japanese egg custard served hot with spicey Italian Pork Jowl (guanciale)",
                      price="$6.95", course="Dessert", restaurant=restaurant1)


### PR DESCRIPTION
If the code at 364 was intended to commit the menuItem1 added at 361, then it requires ending parentheses.  Without these parentheses, a commit does not occur here.

Otherwise, it's unclear whether L360 menuItem1 is added to the database, or whether it is replaced by L366 menuItem1 in the staging area before being committed.
