### PR TITLE
fix: Remove restaurant_id variable in delete menu template

### DIFF
--- a/Lesson-3/14_Delete-Menu-Item/deletemenuitem.html
+++ b/Lesson-3/14_Delete-Menu-Item/deletemenuitem.html
@@ -3,7 +3,7 @@
 <body>
 <h1> Are you sure you want to delete {{item.name}}? </h1>
 
-<form action="{{ url_for('deleteMenuItem',restaurant_id = item.restaurant_id, menu_id=item.id)}}" method = 'post'>
+<form action="{{ url_for('deleteMenuItem', restaurant_id=item.restaurant_id, menu_id=item.id)}}" method = 'post'>
 
 <input type='submit', value = 'Delete'>
 
@@ -12,7 +12,7 @@
 
 </form>
 
-<a href = "{{ url_for('restaurantMenu', restaurant_id = restaurant_id)}}"> Cancel </a>
+<a href = "{{ url_for('restaurantMenu', restaurant_id=item.restaurant_id)}}"> Cancel </a>
 </body>
 
 </html>


### PR DESCRIPTION
The solution code given is not compatible with the HTML given in the question. Only the menu item variable is passed to the delete template, not the restaurant_id variable. But this data is in the item variable in any case.