### PR TITLE
Change status code to reflect successful Post

### DIFF
--- a/Lesson-2/post-web-server/webserver.py
+++ b/Lesson-2/post-web-server/webserver.py
@@ -37,7 +37,7 @@ class webServerHandler(BaseHTTPRequestHandler):
 
     def do_POST(self):
         try:
-            self.send_response(301)
+            self.send_response(201)
             self.send_header('Content-type', 'text/html')
             self.end_headers()
             ctype, pdict = cgi.parse_header(


### PR DESCRIPTION
I noticed the status code in the response for a successful POST was 301 rather than 201.