### PR TITLE
Fix:  line 380, wrong print syntax

### DIFF
--- a/Lesson_1/lotsofmenus.py
+++ b/Lesson_1/lotsofmenus.py
@@ -377,4 +377,4 @@ session.add(menuItem1)
 session.commit()
 
 
-print "added menu items!"
+print("added menu items!")


### PR DESCRIPTION
Fix the print Syntax :  Missing parentheses in call to 'print'