### PR TITLE
PEP3105-compatible print statements

### DIFF
--- a/Lesson-2/first-web-server/webserver.py
+++ b/Lesson-2/first-web-server/webserver.py
@@ -11,7 +11,7 @@ class WebServerHandler(BaseHTTPRequestHandler):
             message = ""
             message += "<html><body>Hello!</body></html>"
             self.wfile.write(message)
-            print message
+            print(message)
             return
         else:
             self.send_error(404, 'File Not Found: %s' % self.path)
@@ -21,10 +21,10 @@ def main():
     try:
         port = 8080
         server = HTTPServer(('', port), WebServerHandler)
-        print "Web Server running on port %s" % port
+        print("Web Server running on port %s" % port)
         server.serve_forever()
     except KeyboardInterrupt:
-        print " ^C entered, stopping web server...."
+        print(" ^C entered, stopping web server....")
         server.socket.close()
 
 if __name__ == '__main__':

--- a/Lesson-2/hola-server/webserver.py
+++ b/Lesson-2/hola-server/webserver.py
@@ -11,7 +11,7 @@ class webServerHandler(BaseHTTPRequestHandler):
             message = ""
             message += "<html><body>Hello!</body></html>"
             self.wfile.write(message)
-            print message
+            print(message)
             return
 
         if self.path.endswith("/hola"):
@@ -21,7 +21,7 @@ class webServerHandler(BaseHTTPRequestHandler):
             message = ""
             message += "<html><body> &#161 Hola ! </body></html>"
             self.wfile.write(message)
-            print message
+            print(message)
             return
 
         else:
@@ -32,10 +32,10 @@ def main():
     try:
         port = 8080
         server = HTTPServer(('', port), webServerHandler)
-        print "Web Server running on port %s" % port
+        print("Web Server running on port %s" % port)
         server.serve_forever()
     except KeyboardInterrupt:
-        print " ^C entered, stopping web server...."
+        print(" ^C entered, stopping web server....")
         server.socket.close()
 
 if __name__ == '__main__':

--- a/Lesson-4/Final-Project/lotsofmenus.py
+++ b/Lesson-4/Final-Project/lotsofmenus.py
@@ -377,4 +377,4 @@ session.add(menuItem1)
 session.commit()
 
 
-print "added menu items!"
+print("added menu items!")

--- a/Lesson_1/lotsofmenus.py
+++ b/Lesson_1/lotsofmenus.py
@@ -377,4 +377,4 @@ session.add(menuItem1)
 session.commit()
 
 
-print "added menu items!"
+print("added menu items!")


### PR DESCRIPTION
edited print statements to `print()` instead of `print` to comply with PEP 3105 --> https://www.python.org/dev/peps/pep-3105/